### PR TITLE
Remove broken custom scrollbars

### DIFF
--- a/dist/semantic.css
+++ b/dist/semantic.css
@@ -557,72 +557,8 @@ a:not(.rt-reset):hover {
          Scrollbars
 *******************************/
 
-/* Force Simple Scrollbars */
-
-body ::-webkit-scrollbar {
-  -webkit-appearance: none;
-  width: 10px;
-  height: 10px;
-}
-
-body ::-webkit-scrollbar-track {
-  background: rgba(0, 0, 0, 0.1);
-  border-radius: 0;
-}
-
-body ::-webkit-scrollbar-thumb {
-  cursor: pointer;
-  border-radius: 5px;
-  background: rgba(0, 0, 0, 0.25);
-  -webkit-transition: color 0.2s ease;
-  transition: color 0.2s ease;
-}
-
-body ::-webkit-scrollbar-thumb:window-inactive {
-  background: rgba(0, 0, 0, 0.15);
-}
-
-body ::-webkit-scrollbar-thumb:hover {
-  background: rgba(128, 135, 139, 0.8);
-}
-
 body .ui {
-  /* IE11 */
-  scrollbar-face-color: #bfbfbf;
-  scrollbar-shadow-color: #bfbfbf;
-  scrollbar-track-color: #e6e6e6;
-  scrollbar-arrow-color: #e6e6e6;
-  /* firefox : first color thumb, second track*/
-  scrollbar-color: rgba(0, 0, 0, 0.25) rgba(0, 0, 0, 0.1);
   scrollbar-width: thin;
-}
-
-/* Inverted UI */
-
-body .ui.inverted:not(.dimmer)::-webkit-scrollbar-track {
-  background: rgba(255, 255, 255, 0.1);
-}
-
-body .ui.inverted:not(.dimmer)::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.25);
-}
-
-body .ui.inverted:not(.dimmer)::-webkit-scrollbar-thumb:window-inactive {
-  background: rgba(255, 255, 255, 0.15);
-}
-
-body .ui.inverted:not(.dimmer)::-webkit-scrollbar-thumb:hover {
-  background: rgba(255, 255, 255, 0.35);
-}
-
-body .ui.inverted:not(.dimmer) {
-  /* IE11 */
-  scrollbar-face-color: #656565;
-  scrollbar-shadow-color: #656565;
-  scrollbar-track-color: #323232;
-  scrollbar-arrow-color: #323232;
-  /* firefox : first color thumb, second track */
-  scrollbar-color: rgba(255, 255, 255, 0.25) rgba(255, 255, 255, 0.1);
 }
 
 /*******************************


### PR DESCRIPTION
Remove custom scrollbars from semantic, use native scrollbars instead. Keeps `scrollbar-width: thin` set for platforms that support it.

1. Versions of Chromium browsers after 121 ignore `-webkit-scrollbar` in favor of the standard `scrollbar-*` properties, so the custom scrollbars configured here were already not being used in the first place since early 2024.
2. ag-grid was using the `-webkit-scrollbar` values for calculations in Chromium browsers, even though the browser itself was ignoring them. This resulted in broken-looking scrollbars.
3. The hardcoded colors here resulted in scrollbars breaking or becoming invisible when switching theme. Letting the browser/platform control the color allows the scrollbars to look right in both light and dark mode depending on the page setting.
4. For platforms that use overlay scrolling (i.e. MacOS), setting custom scrollbars that deviate from the native behavior can be jarring.

Also see: https://github.com/CyberSkyline/cyberskyline/pull/3956